### PR TITLE
fix: Add Dreamcast platform mappings for NextUI and Spruce

### DIFF
--- a/constants/cfw/nextui/platforms.json
+++ b/constants/cfw/nextui/platforms.json
@@ -39,7 +39,9 @@
   "cpet": [
     "Commodore PET (PET)"
   ],
-  "dc": [],
+  "dc": [
+    "Sega Dreamcast (DC)"
+  ],
   "doom": [
     "Doom (PRBOOM)"
   ],

--- a/constants/cfw/spruce/platforms.json
+++ b/constants/cfw/spruce/platforms.json
@@ -37,7 +37,9 @@
     "COLECO"
   ],
   "cpet": [],
-  "dc": [],
+  "dc": [
+    "DC"
+  ],
   "doom": [
     "DOOM"
   ],


### PR DESCRIPTION
## What
This PR adds Dreamcast platform directory mappings for NextUI and Spruce CFWs, which were previously empty and causing Dreamcast ROMs to fail during platform mapping.

## Why
Dreamcast ROMs could not be mapped in NextUI and Spruce because the platform mapping arrays were empty (`"dc": []`) in their configuration files. This broke:
- Platform directory creation
- ROM downloads to Dreamcast directories  
- Save synchronization for Dreamcast games

## How
Updated the platform mapping configurations with the correct directory names:

**NextUI** (`constants/cfw/nextui/platforms.json`):
```json
"dc": ["Sega Dreamcast (DC)"]
```
- Follows NextUI's `Full Name (TAG)` naming convention
- Matches existing patterns like `"Nintendo Entertainment System (FC)"`

**Spruce** (`constants/cfw/spruce/platforms.json`):
```json
"dc": ["DC"]
```
- Follows Spruce's simple uppercase tag convention
- Matches existing patterns like `"ARCADE"`, `"AMIGA"`, `"CPC"`

### Technical Details
The mapping system uses these arrays to:
1. Match platform slugs to CFW-specific directory names
2. Extract tags for NextUI using `ParseTag()` (regex: `\((.*?)\)`)
3. Enable proper directory validation and creation

Empty arrays caused `RomMSlugToCFW()` to return an empty string, breaking directory matching in `settings_platform_mapping.go:205-219`.

## Testing
- ✅ JSON syntax validated for both files
- ✅ Follows existing CFW naming conventions
- ✅ Enables Dreamcast platform mapping UI
- ✅ Allows ROM directory creation
- ✅ Supports ROM downloads and save sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)