### PR TITLE
Improves version comparison with prerelease support

### DIFF
--- a/update/version.go
+++ b/update/version.go
@@ -7,23 +7,29 @@ import (
 )
 
 type Version struct {
-	Major int
-	Minor int
-	Patch int
+	Major      int
+	Minor      int
+	Patch      int
+	Prerelease string // e.g., "beta.1" from "1.2.0-beta.1"
 }
 
 func ParseVersion(v string) (Version, error) {
 	v = strings.TrimPrefix(v, "v")
 
 	parts := strings.SplitN(v, "-", 2)
-	v = parts[0]
+	versionStr := parts[0]
+	var prerelease string
+	if len(parts) > 1 {
+		prerelease = parts[1]
+	}
 
-	segments := strings.Split(v, ".")
+	segments := strings.Split(versionStr, ".")
 	if len(segments) < 1 || len(segments) > 3 {
 		return Version{}, fmt.Errorf("invalid version format: %s", v)
 	}
 
 	var version Version
+	version.Prerelease = prerelease
 
 	if len(segments) >= 1 {
 		major, err := strconv.Atoi(segments[0])
@@ -82,6 +88,31 @@ func CompareVersions(current, latest string) int {
 	}
 	if currentVer.Patch > latestVer.Patch {
 		return 1
+	}
+
+	// If numeric versions are equal, compare prerelease status
+	// According to semver: a version without a prerelease is newer than one with a prerelease
+	currentHasPrerelease := currentVer.Prerelease != ""
+	latestHasPrerelease := latestVer.Prerelease != ""
+
+	if !currentHasPrerelease && latestHasPrerelease {
+		// Current is a full release, latest is prerelease - current is newer
+		return 1
+	}
+	if currentHasPrerelease && !latestHasPrerelease {
+		// Current is prerelease, latest is full release - latest is newer
+		return -1
+	}
+	if currentHasPrerelease && latestHasPrerelease {
+		// Both are prereleases - compare prerelease strings lexicographically
+		// For simplicity, we'll just do a string comparison
+		// In practice, this handles cases like "beta.1" vs "beta.2"
+		if currentVer.Prerelease < latestVer.Prerelease {
+			return -1
+		}
+		if currentVer.Prerelease > latestVer.Prerelease {
+			return 1
+		}
 	}
 
 	return 0

--- a/update/version_test.go
+++ b/update/version_test.go
@@ -1,0 +1,109 @@
+package update
+
+import (
+	"testing"
+)
+
+func TestParseVersion(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected Version
+		wantErr  bool
+	}{
+		{"v1.2.3", Version{Major: 1, Minor: 2, Patch: 3, Prerelease: ""}, false},
+		{"1.2.3", Version{Major: 1, Minor: 2, Patch: 3, Prerelease: ""}, false},
+		{"v1.2.0-beta.1", Version{Major: 1, Minor: 2, Patch: 0, Prerelease: "beta.1"}, false},
+		{"1.2.0-beta.1", Version{Major: 1, Minor: 2, Patch: 0, Prerelease: "beta.1"}, false},
+		{"v1.0.0-alpha", Version{Major: 1, Minor: 0, Patch: 0, Prerelease: "alpha"}, false},
+		{"1.0", Version{Major: 1, Minor: 0, Patch: 0, Prerelease: ""}, false},
+		{"1", Version{Major: 1, Minor: 0, Patch: 0, Prerelease: ""}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got, err := ParseVersion(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseVersion(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr {
+				if got.Major != tt.expected.Major || got.Minor != tt.expected.Minor || got.Patch != tt.expected.Patch || got.Prerelease != tt.expected.Prerelease {
+					t.Errorf("ParseVersion(%q) = %+v, want %+v", tt.input, got, tt.expected)
+				}
+			}
+		})
+	}
+}
+
+func TestCompareVersions(t *testing.T) {
+	tests := []struct {
+		current  string
+		latest   string
+		expected int // -1 if current < latest, 0 if equal, 1 if current > latest
+		desc     string
+	}{
+		// Normal version comparisons
+		{"1.0.0", "1.0.1", -1, "patch version newer"},
+		{"1.0.1", "1.0.0", 1, "patch version older"},
+		{"1.0.0", "1.1.0", -1, "minor version newer"},
+		{"1.1.0", "1.0.0", 1, "minor version older"},
+		{"1.0.0", "2.0.0", -1, "major version newer"},
+		{"2.0.0", "1.0.0", 1, "major version older"},
+		{"1.0.0", "1.0.0", 0, "same version"},
+
+		// Beta vs full release - THE KEY FIX
+		{"v1.2.0-beta.1", "v1.2.0", -1, "beta should recognize full release as newer"},
+		{"v1.2.0", "v1.2.0-beta.1", 1, "full release should be newer than beta"},
+		{"1.2.0-beta.1", "1.2.0", -1, "beta should recognize full release as newer (no v prefix)"},
+		{"1.2.0", "1.2.0-beta.1", 1, "full release should be newer than beta (no v prefix)"},
+
+		// Beta vs beta
+		{"v1.2.0-beta.1", "v1.2.0-beta.2", -1, "newer beta should be recognized"},
+		{"v1.2.0-beta.2", "v1.2.0-beta.1", 1, "older beta should be recognized"},
+		{"v1.2.0-beta.1", "v1.2.0-beta.1", 0, "same beta versions"},
+
+		// Different prerelease types
+		{"v1.2.0-alpha", "v1.2.0-beta.1", -1, "alpha < beta"},
+		{"v1.2.0-beta.1", "v1.2.0-alpha", 1, "beta > alpha"},
+
+		// Edge cases
+		{"v1.2.0-beta.1", "v1.2.1", -1, "beta should recognize higher patch as newer"},
+		{"v1.2.1", "v1.2.0-beta.1", 1, "higher patch should be newer than beta"},
+		{"v1.2.0-beta.1", "v1.3.0", -1, "beta should recognize higher minor as newer"},
+		{"v1.3.0", "v1.2.0-beta.1", 1, "higher minor should be newer than beta"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			got := CompareVersions(tt.current, tt.latest)
+			if got != tt.expected {
+				t.Errorf("CompareVersions(%q, %q) = %d, want %d", tt.current, tt.latest, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestIsNewerVersion(t *testing.T) {
+	tests := []struct {
+		current  string
+		latest   string
+		expected bool
+		desc     string
+	}{
+		{"v1.2.0-beta.1", "v1.2.0", true, "beta should see full release as newer"},
+		{"v1.2.0", "v1.2.0-beta.1", false, "full release should not see beta as newer"},
+		{"v1.1.0", "v1.2.0", true, "older version should see newer as newer"},
+		{"v1.2.0", "v1.1.0", false, "newer version should not see older as newer"},
+		{"v1.2.0", "v1.2.0", false, "same version should not be newer"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			got := IsNewerVersion(tt.current, tt.latest)
+			if got != tt.expected {
+				t.Errorf("IsNewerVersion(%q, %q) = %v, want %v", tt.current, tt.latest, got, tt.expected)
+			}
+		})
+	}
+}
+


### PR DESCRIPTION
Extends the version comparison logic to correctly handle and compare versions including prerelease identifiers (e.g., "beta.1").

Ensures that full releases are considered newer than prereleases, and prereleases are compared lexicographically.

Adds comprehensive unit tests to cover various version comparison scenarios, including normal versions, beta versions, and edge cases.

This addresses issue #63.

I have tested this on both desktop by manually setting version in version/version.go, and on my Anbernic RG35XX+ running MuOS.