### PR TITLE
fix(muos): handle grout icons for muos jacaranda and prior

### DIFF
--- a/scripts/muOS/mux_launch.sh
+++ b/scripts/muOS/mux_launch.sh
@@ -27,7 +27,6 @@ if [ -n "$THEME" ]; then
         "/opt/muos/browse/SD2 (sdcard)/MUOS/theme/${THEME}/glyph/muxapp"
     )
 
-    # Copie dans chaque dossier cible
     for DIR in "${TARGETS[@]}"; do
         if [ -d "$DIR" ]; then
             cp "$GROUT_ICON_PATH" "$DIR/grout.png"


### PR DESCRIPTION
<img width="773" height="210" alt="image" src="https://github.com/user-attachments/assets/8fbd5ff1-0ab7-4ea5-912e-199786463566" />

Since the latest muos version, it does not extract the theme to `active` folder