### PR TITLE
Fix save directory for PSX on MUOS

### DIFF
--- a/cfw/muos/data/save_directories.json
+++ b/cfw/muos/data/save_directories.json
@@ -275,7 +275,7 @@
     "file/PPSSPP"
   ],
   "psx": [
-    "file/PCSX ReARMed",
+    "file/PCSX-ReARMed",
     "file/Beetle PSX",
     "file/DuckStation",
     "file/SwanStation"


### PR DESCRIPTION
PCSX ReARMed save directory on MUOS has a dash instead of a space

<img width="287" height="250" alt="muOS_20260323_1443_0" src="https://github.com/user-attachments/assets/651c7401-57ce-4d1e-b18c-e099def4d126" />
