### PR TITLE
Fix save directory for PSP on MUOS

### DIFF
--- a/cfw/muos/data/save_directories.json
+++ b/cfw/muos/data/save_directories.json
@@ -271,7 +271,7 @@
     "file/External"
   ],
   "psp": [
-    "file/PPSSPP (External)",
+    "file/PPSSPP-Ext",
     "file/PPSSPP"
   ],
   "psx": [


### PR DESCRIPTION
PSP (External) save location on MUOS is PPSSPP-Ext

<img width="285" height="241" alt="muOS_20260323_1504_0" src="https://github.com/user-attachments/assets/e83dbce6-21ec-47d4-9d5b-4111b00814dc" />
