### PR TITLE
fix: use actual fetched count for sync tracking and drop legacy platf…

### DIFF
--- a/cache/games.go
+++ b/cache/games.go
@@ -129,7 +129,7 @@ func anySliceToStrings(items []any) []string {
 func resolveLookupID(tx *sql.Tx, lookupTable, value string, idCache map[string]int64) (int64, error) {
 	// Create a unique key for the map (e.g., "genres:Action")
 	cacheKey := lookupTable + ":" + value
-	
+
 	// If we already looked this up recently, return it instantly!
 	if id, ok := idCache[cacheKey]; ok {
 		return id, nil
@@ -141,12 +141,12 @@ func resolveLookupID(tx *sql.Tx, lookupTable, value string, idCache map[string]i
 	}
 	var id int64
 	err = tx.QueryRow("SELECT id FROM "+lookupTable+" WHERE name = ?", value).Scan(&id)
-	
+
 	// Save it to the map so we never query the DB for this exact string again
 	if err == nil {
 		idCache[cacheKey] = id
 	}
-	
+
 	return id, err
 }
 

--- a/cache/manager.go
+++ b/cache/manager.go
@@ -145,8 +145,8 @@ func (cm *Manager) enableBulkLoadMode() {
 	pragmas := []string{
 		"PRAGMA synchronous = OFF",
 		"PRAGMA journal_mode = OFF",
-		"PRAGMA cache_size = -4000",    // -4000 means exactly 4MB of RAM!
-		"PRAGMA temp_store = DEFAULT",  // Use the SD card for temp tables, not RAM!
+		"PRAGMA cache_size = -4000",   // -4000 means exactly 4MB of RAM!
+		"PRAGMA temp_store = DEFAULT", // Use the SD card for temp tables, not RAM!
 		"PRAGMA locking_mode = EXCLUSIVE",
 	}
 	for _, p := range pragmas {
@@ -431,13 +431,14 @@ func (cm *Manager) SyncPlatformGames(platforms []romm.Platform) (int, error) {
 	totalGames := 0
 
 	for _, platform := range platforms {
-		if err := cm.fetchPlatformGames(platform, nil); err != nil {
+		count, err := cm.fetchPlatformGames(platform, nil)
+		if err != nil {
 			logger.Error("Failed to sync platform games", "platform", platform.Name, "error", err)
 			cm.RecordPlatformSyncFailure(platform.ID)
 			continue
 		}
-		cm.RecordPlatformSyncSuccess(platform.ID, platform.ROMCount)
-		totalGames += platform.ROMCount
+		cm.RecordPlatformSyncSuccess(platform.ID, count)
+		totalGames += count
 		logger.Debug("Synced platform games", "platform", platform.Name)
 	}
 

--- a/cache/populate.go
+++ b/cache/populate.go
@@ -116,12 +116,12 @@ func (cm *Manager) populateCache(platforms []romm.Platform, progress *atomic.Flo
 	go func() {
 		defer wg.Done()
 		for _, p := range platforms {
-			err := cm.fetchPlatformGames(p, &fetchOpts{
+			count, err := cm.fetchPlatformGames(p, &fetchOpts{
 				client:       client,
 				onProgress:   updateProgress,
 				updatedAfter: updatedAfter,
 			})
-			
+
 			if err != nil {
 				logger.Error("Failed to fetch/save platform games", "platformID", p.ID, "error", err)
 				cm.RecordPlatformSyncFailure(p.ID)
@@ -129,10 +129,10 @@ func (cm *Manager) populateCache(platforms []romm.Platform, progress *atomic.Flo
 					firstErr = err
 				}
 			} else {
-				cm.RecordPlatformSyncSuccess(p.ID, p.ROMCount)
+				cm.RecordPlatformSyncSuccess(p.ID, count)
 			}
 
-			// Aggressively free memory after saving each platform 
+			// Aggressively free memory after saving each platform
 			// Prevents OOM crashes on 128MB devices
 			runtime.GC()
 		}
@@ -171,7 +171,7 @@ type fetchOpts struct {
 	updatedAfter  string
 }
 
-func (cm *Manager) fetchPlatformGames(platform romm.Platform, opts *fetchOpts) error {
+func (cm *Manager) fetchPlatformGames(platform romm.Platform, opts *fetchOpts) (int, error) {
 	if opts == nil {
 		opts = &fetchOpts{}
 	}
@@ -188,8 +188,7 @@ func (cm *Manager) fetchPlatformGames(platform romm.Platform, opts *fetchOpts) e
 
 	for {
 		q := romm.GetRomsQuery{
-			PlatformID:   platform.ID,               // Older RomM instances
-			PlatformIDs:  []int{platform.ID},        // Newer RomM instances
+			PlatformIDs:  []int{platform.ID},
 			Offset:       offset,
 			Limit:        DefaultRomPageSize,
 			UpdatedAfter: opts.updatedAfter,
@@ -201,7 +200,7 @@ func (cm *Manager) fetchPlatformGames(platform romm.Platform, opts *fetchOpts) e
 				"platform", platform.Name,
 				"offset", offset,
 				"error", err)
-			return err
+			return 0, err
 		}
 
 		if offset == 0 {
@@ -241,7 +240,7 @@ func (cm *Manager) fetchPlatformGames(platform romm.Platform, opts *fetchOpts) e
 			"count", len(allGames))
 	}
 
-	return cm.SavePlatformGames(platform.ID, allGames)
+	return len(allGames), cm.SavePlatformGames(platform.ID, allGames)
 }
 
 // fetchAllGames fetches all games from the API in bulk (without platform filter)
@@ -459,7 +458,8 @@ func (cm *Manager) RefreshPlatformGames(platform romm.Platform) error {
 		return ErrNotInitialized
 	}
 
-	return cm.fetchPlatformGames(platform, nil)
+	_, err := cm.fetchPlatformGames(platform, nil)
+	return err
 }
 
 func (cm *Manager) RefreshPlatformGamesWithProgress(platform romm.Platform, progress *atomic.Float64) error {
@@ -473,7 +473,7 @@ func (cm *Manager) RefreshPlatformGamesWithProgress(platform romm.Platform, prog
 		gaba.GetLogger().Debug("Using incremental refresh", "updated_after", updatedAfter)
 	}
 
-	err := cm.fetchPlatformGames(platform, &fetchOpts{
+	_, err := cm.fetchPlatformGames(platform, &fetchOpts{
 		onPctProgress: progress,
 		updatedAfter:  updatedAfter,
 	})

--- a/romm/roms.go
+++ b/romm/roms.go
@@ -126,8 +126,7 @@ type RomFile struct {
 type GetRomsQuery struct {
 	Offset              int    `qs:"offset,omitempty"`
 	Limit               int    `qs:"limit,omitempty"`
-	PlatformID   		int    `qs:"platform_id,omitempty"`  // Keep for backwards compatibility
-	PlatformIDs  		[]int  `qs:"platform_ids,omitempty"` // Add this for newer RomM versions
+	PlatformIDs         []int  `qs:"platform_ids,omitempty"`
 	CollectionID        int    `qs:"collection_id,omitempty"`
 	SmartCollectionID   int    `qs:"smart_collection_id,omitempty"`
 	VirtualCollectionID string `qs:"virtual_collection_id,omitempty"`
@@ -140,7 +139,7 @@ type GetRomsQuery struct {
 }
 
 func (q GetRomsQuery) Valid() bool {
-	return q.Limit > 0 || q.PlatformID > 0 || q.CollectionID > 0 || q.SmartCollectionID > 0 || q.VirtualCollectionID != "" || q.Search != "" || q.OrderBy != "" || q.OrderDir != ""
+	return q.Limit > 0 || len(q.PlatformIDs) > 0 || q.CollectionID > 0 || q.SmartCollectionID > 0 || q.VirtualCollectionID != "" || q.Search != "" || q.OrderBy != "" || q.OrderDir != ""
 }
 
 type GetRomByHashQuery struct {


### PR DESCRIPTION
…orm_id

fetchPlatformGames now returns the count of games actually fetched instead of using the server's total ROMCount, which was incorrect for incremental syncs. Removed deprecated platform_id query param in favor of platform_ids. Applied gofmt.