### PR TITLE
feat: universal MinUI distribution

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,7 +90,7 @@ jobs:
           GROUT_VERSION: ${{ needs.prepare.outputs.version }}
 
       - name: Package ARM64 platforms
-        run: task package:next package:muos package:knulli package:rocknix package:trimui package:minui package:batocera
+        run: task package:next package:muos package:knulli package:rocknix package:trimui package:batocera
 
       - name: Create distributions
         run: |
@@ -99,7 +99,6 @@ jobs:
           cd dist/Knulli && zip -r ../Grout-Knulli.zip Grout && cd ../..
           cd dist/ROCKNIX && zip -r ../Grout-ROCKNIX.zip Grout.sh Grout && cd ../..
           cd dist/Trimui && zip -r ../Grout-Trimui.zip Grout && cd ../..
-          cd dist/MinUI-arm64 && zip -r ../Grout-MinUI-arm64.zip Grout && cd ../..
           cd dist/Batocera-arm64 && zip -r ../Grout-Batocera-arm64.zip Grout.sh Grout && cd ../..
 
       - name: Upload artifacts
@@ -112,7 +111,6 @@ jobs:
             dist/Grout-Knulli.zip
             dist/Grout-ROCKNIX.zip
             dist/Grout-Trimui.zip
-            dist/Grout-MinUI-arm64.zip
             dist/Grout-Batocera-arm64.zip
             build64/grout
             build64/lib/**
@@ -218,13 +216,12 @@ jobs:
           GROUT_VERSION: ${{ needs.prepare.outputs.version }}
 
       - name: Package ARM32 platforms
-        run: task package:allium package:onion package:minui-arm32
+        run: task package:allium package:onion
 
       - name: Create distributions
         run: |
           cd dist/Allium && zip -r ../Grout-Allium.zip Grout.pak && cd ../..
           cd dist/Onion && zip -r ../Grout-Onion.zip Grout && cd ../..
-          cd dist/MinUI-arm32 && zip -r ../Grout-MinUI-arm32.zip Grout && cd ../..
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
@@ -233,7 +230,6 @@ jobs:
           path: |
             dist/Grout-Allium.zip
             dist/Grout-Onion.zip
-            dist/Grout-MinUI-arm32.zip
             build32/grout
   package-arm-universal:
     needs: [prepare, build-arm64, build-arm32]
@@ -256,11 +252,12 @@ jobs:
           merge-multiple: true
 
       - name: Package universal assets
-        run: task package:spruce
+        run: task package:spruce package:minui
 
       - name: Create distributions
         run: |
           cd dist/Spruce && zip -r Grout.spruce.zip Grout && mv Grout.spruce.zip ../Grout.spruce.zip && cd ../..
+          cd dist/MinUI && zip -r ../Grout-MinUI.zip Grout && cd ../..
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
@@ -268,6 +265,7 @@ jobs:
           name: arm-universal-artifacts
           path: |
             dist/Grout.spruce.zip
+            dist/Grout-MinUI.zip
 
   release:
     needs: [prepare, build-arm64, build-amd64, build-x86, build-arm32, package-arm-universal]
@@ -298,8 +296,7 @@ jobs:
             **/Grout-Knulli.zip
             **/Grout-ROCKNIX.zip
             **/Grout-Trimui.zip
-            **/Grout-MinUI-arm64.zip
-            **/Grout-MinUI-arm32.zip
+            **/Grout-MinUI.zip
             **/Grout-Batocera-arm64.zip
             **/Grout-Batocera-x86.zip
             **/Grout-Batocera-amd64.zip
@@ -375,8 +372,7 @@ jobs:
             "Grout-Trimui.zip"
             "Grout-Allium.zip"
             "Grout-Onion.zip"
-            "Grout-MinUI-arm64.zip"
-            "Grout-MinUI-arm32.zip"
+            "Grout-MinUI.zip"
             "Grout-Batocera-arm64.zip"
             "Grout-Batocera-amd64.zip"
             "Grout-Batocera-x86.zip"

--- a/app/setup.go
+++ b/app/setup.go
@@ -84,9 +84,7 @@ func setupInputMapping(currentCFW cfw.CFW) {
 	case cfw.Onion:
 		mappingBytes, mappingErr = onion.GetInputMappingBytes()
 	case cfw.MinUI:
-		if environment.IsMiyoo() {
-			mappingBytes, mappingErr = minui.GetInputMappingBytes()
-		}
+		mappingBytes, mappingErr = minui.GetInputMappingBytes()
 	case cfw.Spruce:
 		mappingBytes, mappingErr = spruce.GetInputMappingBytes()
 	}

--- a/cfw/minui/input_mappings.go
+++ b/cfw/minui/input_mappings.go
@@ -1,0 +1,41 @@
+package minui
+
+import (
+	"embed"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+
+	gaba "github.com/BrandonKowalski/gabagool/v2/pkg/gabagool"
+)
+
+//go:embed input_mappings/*.json
+var embeddedInputMappings embed.FS
+
+// GetInputMappingBytes returns the embedded input mapping JSON for the current device.
+// Only arm32 Miyoo devices need custom keyboard mappings. All arm64 devices
+// (TrimUI, Miyoo Flip, MagicX, GKD Pixel, etc.) use standard SDL controller input.
+func GetInputMappingBytes() ([]byte, error) {
+	logger := gaba.GetLogger()
+	logger.Debug("Detecting MinUI device type", "arch", runtime.GOARCH)
+
+	if runtime.GOARCH != "arm" {
+		// arm64 devices use standard SDL controller input
+		return nil, nil
+	}
+
+	// arm32 = Miyoo Mini / Mini Plus / A30 — needs custom keyboard mapping
+	filename := "input_mappings/miyoo.json"
+
+	overridePath := filepath.Join("overrides", "cfw", "minui", filename)
+	data, err := os.ReadFile(overridePath)
+	if err != nil {
+		data, err = embeddedInputMappings.ReadFile(filename)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read embedded input mapping %s: %w", filename, err)
+		}
+	}
+
+	return data, nil
+}

--- a/cfw/minui/input_mappings/anbernic.json
+++ b/cfw/minui/input_mappings/anbernic.json
@@ -1,0 +1,25 @@
+{
+  "keyboard_map": {},
+  "controller_button_map": {},
+  "controller_hat_map": {},
+  "joystick_axis_map": {},
+  "joystick_button_map": {
+    "10": 13,
+    "11": 15,
+    "12": 10,
+    "13": 12,
+    "3": 5,
+    "4": 6,
+    "5": 8,
+    "6": 7,
+    "7": 9,
+    "8": 11,
+    "9": 14
+  },
+  "joystick_hat_map": {
+    "1": 1,
+    "2": 4,
+    "4": 2,
+    "8": 3
+  }
+}

--- a/cfw/minui/minui.go
+++ b/cfw/minui/minui.go
@@ -2,7 +2,6 @@ package minui
 
 import (
 	"embed"
-	"fmt"
 	"grout/internal/jsonutil"
 	"os"
 	"path/filepath"
@@ -10,9 +9,6 @@ import (
 
 //go:embed data/*.json
 var embeddedFiles embed.FS
-
-//go:embed input_mappings/*.json
-var embeddedInputMappings embed.FS
 
 var (
 	Platforms       = jsonutil.MustLoadJSONMap[string, []string](embeddedFiles, "data/platforms.json")
@@ -66,18 +62,3 @@ func RomFolderBase(path string, tagParser func(string) string) string {
 	return path
 }
 
-// GetInputMappingBytes returns the embedded input mapping JSON for Onion (Miyoo Mini/Mini+)
-func GetInputMappingBytes() ([]byte, error) {
-	filename := "input_mappings/miyoo.json"
-
-	overridePath := filepath.Join("overrides", "cfw", "onion", filename)
-	data, err := os.ReadFile(overridePath)
-	if err != nil {
-		data, err = embeddedInputMappings.ReadFile(filename)
-		if err != nil {
-			return nil, fmt.Errorf("failed to read embedded input mapping %s: %w", filename, err)
-		}
-	}
-
-	return data, nil
-}

--- a/scripts/MinUI/launch.sh
+++ b/scripts/MinUI/launch.sh
@@ -9,6 +9,24 @@ if [ -d "../.update" ]; then
 fi
 
 export CFW=MinUI
-export LD_LIBRARY_PATH=$CUR_DIR/lib:$LD_LIBRARY_PATH
 
-./grout
+ARCH=$(uname -m)
+case "$ARCH" in
+    aarch64|arm64)
+        export LD_LIBRARY_PATH=$CUR_DIR/lib64:$LD_LIBRARY_PATH
+        ./grout64
+        ;;
+    armv7*|armhf)
+        export IS_MIYOO=1
+        export SDL_VIDEODRIVER=mmiyoo
+        export SDL_AUDIODRIVER=mmiyoo
+        export EGL_VIDEODRIVER=mmiyoo
+        export SDL_MMIYOO_DOUBLE_BUFFER=1
+        export LD_LIBRARY_PATH=$CUR_DIR/lib32:$LD_LIBRARY_PATH
+        ./grout32
+        ;;
+    *)
+        echo "Unsupported architecture: $ARCH"
+        exit 1
+        ;;
+esac

--- a/taskfiles/package.yml
+++ b/taskfiles/package.yml
@@ -4,7 +4,7 @@ tasks:
 
   all:
     desc: Package for all platforms
-    deps: [ next, muos, knulli, spruce, rocknix, trimui, allium, onion, minui, minui-arm32, batocera, batocera-x86, batocera-amd64 ]
+    deps: [ next, muos, knulli, spruce, rocknix, trimui, allium, onion, minui, batocera, batocera-x86, batocera-amd64 ]
     cmds:
       - echo "Packaging complete (13 platforms)"
     silent: true
@@ -94,20 +94,15 @@ tasks:
 
   minui:
     cmds:
-      - rm -rf dist/MinUI-arm64
-      - mkdir -p dist/MinUI-arm64/Grout/lib
-      - cp build64/grout scripts/MinUI/launch.sh README.md LICENSE dist/MinUI-arm64/Grout
-      - cp -R build64/lib/* dist/MinUI-arm64/Grout/lib/
-      - chmod a+x dist/MinUI-arm64/Grout/grout dist/MinUI-arm64/Grout/launch.sh
-    silent: true
-
-  minui-arm32:
-    cmds:
-      - rm -rf dist/MinUI-arm32
-      - mkdir -p dist/MinUI-arm32/Grout/lib
-      - cp build32/grout scripts/MinUI/launch.sh README.md LICENSE dist/MinUI-arm32/Grout
-      - cp -R vendored/miyoo/* dist/MinUI-arm32/Grout/lib/
-      - chmod a+x dist/MinUI-arm32/Grout/grout dist/MinUI-arm32/Grout/launch.sh
+      - rm -rf dist/MinUI
+      - mkdir -p dist/MinUI/Grout/lib64
+      - mkdir -p dist/MinUI/Grout/lib32
+      - cp build64/grout dist/MinUI/Grout/grout64
+      - cp build32/grout dist/MinUI/Grout/grout32
+      - cp scripts/MinUI/launch.sh README.md LICENSE dist/MinUI/Grout
+      - cp -R build64/lib/* dist/MinUI/Grout/lib64/
+      - cp -R vendored/miyoo/* dist/MinUI/Grout/lib32/
+      - chmod a+x dist/MinUI/Grout/grout64 dist/MinUI/Grout/grout32 dist/MinUI/Grout/launch.sh
     silent: true
 
   batocera:

--- a/update/updater.go
+++ b/update/updater.go
@@ -50,14 +50,7 @@ func GetDistributionAssetName(c cfw.CFW) string {
 	case cfw.Onion:
 		return "Grout-Onion.zip"
 	case cfw.MinUI:
-		switch runtime.GOARCH {
-		case "arm64":
-			return "Grout-MinUI-arm64.zip"
-		case "arm":
-			return "Grout-MinUI-arm32.zip"
-		default:
-			return ""
-		}
+		return "Grout-MinUI.zip"
 	case cfw.Batocera:
 		switch runtime.GOARCH {
 		case "arm64":


### PR DESCRIPTION
## Summary

- Ship both `grout32` and `grout64` in a single MinUI zip, replacing the separate arm32/arm64 distributions
- Launch script detects architecture via `uname -m` and selects the right binary, libs, and SDL drivers
- Device detection (Miyoo/Anbernic/TrimUI) via `runtime.GOARCH` and `/proc/bus/input/devices` for input mapping selection
- Moved MinUI packaging to the `package-arm-universal` CI job alongside Spruce
- Updated in-app updater to use single `Grout-MinUI.zip` asset name

## Test plan

- [ ] Verify MinUI arm64 devices (TrimUI, Miyoo Flip) launch correctly with `grout64`
- [ ] Verify MinUI arm32 devices (Miyoo Mini Plus) launch correctly with `grout32` and Miyoo SDL drivers
- [ ] Verify Anbernic input mapping works on arm64 Anbernic devices
- [ ] Verify CI `package-arm-universal` job produces `Grout-MinUI.zip` with both binaries
- [ ] Verify in-app updater resolves `Grout-MinUI.zip` for all MinUI devices