### PR TITLE
More MUOS save file locations.

### DIFF
--- a/cfw/muos/data/save_directories.json
+++ b/cfw/muos/data/save_directories.json
@@ -287,14 +287,14 @@
     "file/EasyRPG Player"
   ],
   "saturn": [
-    "file/YabaSanshiro (External)",
+    "file/YabaSanshiro-Ext",
     "file/Beetle Saturn",
     "file/YabaSanshiro",
     "file/YabaSanshiro (External - No BIOS)",
     "file/Yabause"
   ],
   "scummvm": [
-    "file/ScummVM (External)",
+    "file/ScummVM-Ext",
     "file/ScummVM"
   ],
   "sega32": [


### PR DESCRIPTION
Not sure how important capitalization is, but some are just that. Other changes are to external emulators or dash-space-underscore differences. All were derived from an ai generated list and/or searching for "External" and compared to actual MUOS activity by launching games with those cores and seeing what folder name they used. 