### PR TITLE
Updated list of tested devices for muOS

### DIFF
--- a/docs/getting-started/install-muos.md
+++ b/docs/getting-started/install-muos.md
@@ -6,16 +6,17 @@ This guide will help you install Grout on devices running [muOS][muos].
 
 Grout has been tested on the following devices running muOS 2508.4 Loose Goose:
 
-| Manufacturer | Device    |
-|--------------|-----------|
-| Anbernic     | RG34XX    |
-| Anbernic     | RG34XXSP  |
-| Anbernic     | RG35XX-H  |
-| Anbernic     | RG35XXSP  |
-| Anbernic     | RG40XXV   |
-| Anbernic     | RG CUBE   |
-| TrimUI       | Brick     |
-| TrimUI       | Smart Pro |
+| Manufacturer | Device      |
+|--------------|-------------|
+| Anbernic     | RG34XX      |
+| Anbernic     | RG34XXSP    |
+| Anbernic     | RG35XX Plus |
+| Anbernic     | RG35XX-H    |
+| Anbernic     | RG35XXSP    |
+| Anbernic     | RG40XXV     |
+| Anbernic     | RG CUBE     |
+| TrimUI       | Brick       |
+| TrimUI       | Smart Pro   |
 
 _Please help verify compatibility on other devices by reporting your results!_
 


### PR DESCRIPTION
I am currently running Grout on my Anbernic RG35XX Plus and can verify I have run into zero issues.

Here are the following versions for everything:
RomM `4.8.0`
Grout `v4.8.0.0`
muOS version: `2601.0 JACARANDA*`

I recognize the muOS version doesn't match whats stated on the docs. I don't have any of those other devices to test however so I don't know if the docs should be updated to show the newest muOS version as well.

This is my first time contributing to Grout and it is just a simple documentation update but I hope to contribute more significantly in the future!