### PR TITLE
MinUI Base Path / Input Mapping for MagicX Zero28 impacting TrimUI

### DIFF
--- a/cfw/minui/input_mappings.go
+++ b/cfw/minui/input_mappings.go
@@ -11,6 +11,8 @@ import (
 	gaba "github.com/BrandonKowalski/gabagool/v2/pkg/gabagool"
 )
 
+const DeviceType = "MINUI_DEVICE"
+
 //go:embed input_mappings/*.json
 var embeddedInputMappings embed.FS
 
@@ -20,8 +22,25 @@ const (
 	DeviceMiyoo    Device = "miyoo"
 	DeviceAnbernic Device = "anbernic"
 	DeviceZero28   Device = "zero28"
+	DeviceTrimui   Device = "trimui"
 	DeviceGeneric  Device = "generic"
 )
+
+func detectDeviceByEnv() Device {
+	logger := gaba.GetLogger()
+	logger.Debug("Detecting MinUI device type", "env", DeviceType)
+	deviceType := os.Getenv(DeviceType)
+
+	switch deviceType {
+	case "tg5040":
+		return DeviceTrimui
+	case "zero28":
+		return DeviceZero28
+	default:
+		logger.Warn("Unknown MinUI device type", "value", deviceType)
+		return DeviceGeneric
+	}
+}
 
 func DetectDevice() Device {
 	logger := gaba.GetLogger()
@@ -31,17 +50,18 @@ func DetectDevice() Device {
 		return DeviceMiyoo
 	}
 
+	minuiDeviceType := detectDeviceByEnv()
 	// Anbernic devices use the Allwinner H616 SoC
 	compatible, err := os.ReadFile("/sys/firmware/devicetree/base/compatible")
 	if err == nil && strings.Contains(string(compatible), "allwinner,h616") {
 		return DeviceAnbernic
 	}
-	if err == nil && strings.Contains(string(compatible), "allwinner,a133") {
+	if err == nil && strings.Contains(string(compatible), "allwinner,a133") && minuiDeviceType == DeviceZero28 {
 		return DeviceZero28
 	}
 
 	// TODO discover if Miyoo Flip and Others are fine with standard config
-	// TrimUI (a133p), Miyoo Flip (potentially idk don't own one), and others use standard SDL controller input
+	// Miyoo Flip (potentially idk don't own one), and others use standard SDL controller input
 	return DeviceGeneric
 }
 

--- a/cfw/minui/input_mappings.go
+++ b/cfw/minui/input_mappings.go
@@ -60,8 +60,6 @@ func DetectDevice() Device {
 		return DeviceZero28
 	}
 
-	// TODO discover if Miyoo Flip and Others are fine with standard config
-	// Miyoo Flip (potentially idk don't own one), and others use standard SDL controller input
 	return DeviceGeneric
 }
 

--- a/cfw/minui/minui.go
+++ b/cfw/minui/minui.go
@@ -15,11 +15,26 @@ var (
 	SaveDirectories = jsonutil.MustLoadJSONMap[string, []string](embeddedFiles, "data/save_directories.json")
 )
 
+var cachedBasePath string
+
 func GetBasePath() string {
 	if basePath := os.Getenv("BASE_PATH"); basePath != "" {
 		return basePath
 	}
-	return "/mnt/SDCARD"
+
+	if cachedBasePath != "" {
+		return cachedBasePath
+	}
+
+	for _, candidate := range []string{"/mnt/SDCARD", "/mnt/sdcard"} {
+		if _, err := os.Stat(candidate); err == nil {
+			cachedBasePath = candidate
+			return cachedBasePath
+		}
+	}
+
+	cachedBasePath = "/mnt/mmc"
+	return cachedBasePath
 }
 
 func GetRomDirectory() string {
@@ -61,4 +76,3 @@ func RomFolderBase(path string, tagParser func(string) string) string {
 	}
 	return path
 }
-

--- a/docs/getting-started/install-minui.md
+++ b/docs/getting-started/install-minui.md
@@ -10,7 +10,10 @@ Grout has been tested on the following devices running MinUI:
 |--------------|-------------|
 | Miyoo        | A30         |
 | Miyoo        | Mini Plus   |
+| Miyoo        | Flip V2     |
 | Magicx       | Mini Zero28 |
+| Trimui       | Smart Pro   |
+| Trimui       | Brick       |
 
 _Please help verify compatibility on other devices by reporting your results!_
 

--- a/docs/getting-started/install-minui.md
+++ b/docs/getting-started/install-minui.md
@@ -11,6 +11,7 @@ Grout has been tested on the following devices running MinUI:
 | Miyoo        | A30         |
 | Miyoo        | Mini Plus   |
 | Miyoo        | Flip V2     |
+| Miyoo        | Mini Flip   |
 | Magicx       | Mini Zero28 |
 | Trimui       | Smart Pro   |
 | Trimui       | Brick       |

--- a/docs/getting-started/install-minui.md
+++ b/docs/getting-started/install-minui.md
@@ -8,6 +8,8 @@ Grout has been tested on the following devices running MinUI:
 
 | Manufacturer | Device      |
 |--------------|-------------|
+| Anbernic     | RG 35xxsp   |
+| Anbernic     | RG CubeXX   |
 | Miyoo        | A30         |
 | Miyoo        | Mini Plus   |
 | Miyoo        | Flip V2     |

--- a/docs/getting-started/install-minui.md
+++ b/docs/getting-started/install-minui.md
@@ -13,6 +13,7 @@ Grout has been tested on the following devices running MinUI:
 | Miyoo        | Flip V2     |
 | Miyoo        | Mini Flip   |
 | Magicx       | Mini Zero28 |
+| Powkiddy     | RGB30       |
 | Trimui       | Smart Pro   |
 | Trimui       | Brick       |
 

--- a/scripts/MinUI/launch.sh
+++ b/scripts/MinUI/launch.sh
@@ -9,6 +9,10 @@ if [ -d "../.update" ]; then
 fi
 
 export CFW=MinUI
+# Set the device type for MinUI
+# This $PLATFORM is automatically set by MinUI, we map it another variable just to remember where it comes from.
+# Possible values: miyoomini trimuismart rg35xx rg35xxplus my355 tg5040 zero28 rgb30 m17 gkdpixel my282 magicmini
+export MINUI_DEVICE="$PLATFORM"
 
 ARCH=$(uname -m)
 case "$ARCH" in


### PR DESCRIPTION
Addressing the issue:  https://github.com/rommapp/grout/issues/187

[fix(minui): check path exist before returning base path](https://github.com/rommapp/grout/pull/197/commits/4d70a353d419710cf4a75005b8a4628e45decaf4) :
Before returning the base path for minui, we check that the path exists, we don't know at this point if the user have a single or dual sd card setup. But, since minui does symlink folder and it's case sensitive, we check all the possible paths, cache it, and return it.

[feat(minui/trimui): Working on brick and smart pro](https://github.com/rommapp/grout/pull/197/commits/cf6fffbce898ebb5f53050056401e1ffcc24123c) :
Since trimui and magicx zero28 share the same chip, and our device check was on that information, the input map and screen rotation was applied on TSP