### PR TITLE
Align GBA rom location with save location on MinUi

### DIFF
--- a/cfw/minui/data/platforms.json
+++ b/cfw/minui/data/platforms.json
@@ -56,8 +56,8 @@
     "Game Boy (GB)"
   ],
   "gba": [
-    "Game Boy Advance (MGBA)",
-    "Game Boy Advance (GBA)"
+    "Game Boy Advance (GBA)",
+    "Game Boy Advance (MGBA)"
   ],
   "gbc": [
     "Game Boy Color (GBC)"


### PR DESCRIPTION
Change default gba rom folder to GPSP to align with Grout default save folder location and base MinUi without extras installed.