### PR TITLE
Change artwork downloading for MinUI

### DIFF
--- a/cfw/minui/minui.go
+++ b/cfw/minui/minui.go
@@ -50,7 +50,7 @@ func GetBaseSavePath() string {
 }
 
 func GetArtDirectory(romDir string) string {
-	return filepath.Join(romDir, ".media")
+	return filepath.Join(romDir, ".res")
 }
 
 func GetBIOSFilePaths(relativePath, platformFSSlug string) []string {

--- a/ui/download.go
+++ b/ui/download.go
@@ -395,9 +395,13 @@ func (s *DownloadScreen) buildDownloads(config internal.Config, host romm.Host, 
 		if config.DownloadArt && (g.PathCoverLarge != "" || g.PathCoverSmall != "" || g.URLCover != "") {
 			// Prepare download for cover art
 			artDir := config.GetArtDirectory(gamePlatform)
-			artFileName := g.FsNameNoExt + ".png"
+			var artFileName string
+			if cfw.GetCFW() == cfw.MinUI && len(g.Files) > 0 {
+				artFileName = g.Files[0].FileName + ".png"
+			} else {
+				artFileName = g.FsNameNoExt + ".png"
+			}
 			artLocation := filepath.Join(artDir, artFileName)
-
 			coverURL := g.GetArtworkURL(config.ArtKind, host)
 			gamelistRomEntry.ArtLocation.ImagePath = artLocation
 


### PR DESCRIPTION
MinUI uses .res instead of .media. Changed that in minui.go

Also needs gamename.ext.png, so added cfw detection and changed image name generation for MinUi only.

Tested to make sure it works properly on MinUi and compared to OnionOS to make sure that the filename was only changed on MinUi. 