### PR TITLE
fix(nextui/miyoo): disable keyboard and joystick event

### DIFF
--- a/app/setup.go
+++ b/app/setup.go
@@ -8,6 +8,7 @@ import (
 	"grout/cfw/koriki"
 	"grout/cfw/minui"
 	"grout/cfw/muos"
+	"grout/cfw/nextui"
 	"grout/cfw/onion"
 	"grout/cfw/rocknix"
 	"grout/cfw/spruce"
@@ -118,7 +119,8 @@ func initFramework(currentCFW cfw.CFW) {
 		gabaOptions.DisplayOrientation = gaba.OrientationRotate90
 	}
 
-	if currentCFW == cfw.MinUI && minui.DetectDevice() == minui.DeviceMiyooFlip {
+	if (currentCFW == cfw.MinUI && minui.DetectDevice() == minui.DeviceMiyooFlip) ||
+		(currentCFW == cfw.NextUI && nextui.DetectDevice() == nextui.DeviceMiyooFlip) {
 		gabaOptions.DisabledInputSources = gaba.DisabledInputSources{
 			Keyboard: true,
 			Joystick: true,

--- a/cfw/nextui/device.go
+++ b/cfw/nextui/device.go
@@ -1,0 +1,47 @@
+package nextui
+
+import (
+	"os"
+	"runtime"
+
+	gaba "github.com/BrandonKowalski/gabagool/v2/pkg/gabagool"
+)
+
+const DeviceType = "NEXTUI_DEVICE"
+
+type Device string
+
+const (
+	DeviceMiyooFlip Device = "miyooflip"
+	DeviceTrimui    Device = "trimui"
+	DeviceGeneric   Device = "generic"
+)
+
+func detectDeviceByEnv() Device {
+	logger := gaba.GetLogger()
+	logger.Debug("Detecting NextUI device type", "env", DeviceType)
+	deviceType := os.Getenv(DeviceType)
+
+	switch deviceType {
+	case "tg5040", "tg5050":
+		return DeviceTrimui
+	case "my355":
+		return DeviceMiyooFlip
+	default:
+		logger.Warn("Unknown NextUI device type", "value", deviceType)
+		return DeviceGeneric
+	}
+}
+
+func DetectDevice() Device {
+	logger := gaba.GetLogger()
+	logger.Debug("Detecting NextUI device type", "arch", runtime.GOARCH)
+
+	deviceType := detectDeviceByEnv()
+	switch deviceType {
+	case DeviceMiyooFlip:
+		return deviceType
+	}
+
+	return DeviceGeneric
+}

--- a/scripts/NextUI/launch.sh
+++ b/scripts/NextUI/launch.sh
@@ -9,6 +9,8 @@ if [ -d ".update" ]; then
 fi
 
 export CFW=NEXTUI
+# This $PLATFORM is automatically set by NextUI, we map it another variable just to remember where it comes from.
+export NEXTUI_DEVICE="$PLATFORM"
 export LD_LIBRARY_PATH=$CUR_DIR/lib:$LD_LIBRARY_PATH
 
 ./grout


### PR DESCRIPTION
Addressed: #237 

This is part of the bug of #199 present for spruce too, the device seems to send input code from keyboard and joystick. It prevents some weird behavivior on the virtual keyboard