### PR TITLE
Attempt to fix NextUI (and other CFW platforms) save sync path resolution when local variants are mismatched

### DIFF
--- a/cfw/roms.go
+++ b/cfw/roms.go
@@ -88,7 +88,8 @@ func scanRomsByPlatform(baseRomDir string, platformMap map[string][]string, conf
 
 				if !matched {
 					if config != nil {
-						if relPath, ok := config.GetDirectoryMapping(fsSlug); ok {
+						rommFSSlug := config.ResolveRommFSSlug(fsSlug)
+						if relPath, ok := config.GetDirectoryMapping(rommFSSlug); ok {
 							if stringutil.ParseTag(relPath) == tag {
 								matched = true
 							}
@@ -97,11 +98,15 @@ func scanRomsByPlatform(baseRomDir string, platformMap map[string][]string, conf
 				}
 
 				if matched {
+					rommFSSlug := fsSlug
+					if config != nil {
+						rommFSSlug = config.ResolveRommFSSlug(fsSlug)
+					}
 					romDir := filepath.Join(baseRomDir, dirName)
-					roms := scanRomDirectory(fsSlug, romDir)
+					roms := scanRomDirectory(rommFSSlug, romDir)
 					if len(roms) > 0 {
-						result[fsSlug] = append(result[fsSlug], roms...)
-						logger.Debug("Found ROMs for platform", "fsSlug", fsSlug, "dir", dirName, "count", len(roms))
+						result[rommFSSlug] = append(result[rommFSSlug], roms...)
+						logger.Debug("Found ROMs for platform", "fsSlug", rommFSSlug, "dir", dirName, "count", len(roms))
 					}
 				}
 			}

--- a/cfw/roms_test.go
+++ b/cfw/roms_test.go
@@ -1,0 +1,56 @@
+package cfw
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+type romScanConfigStub struct {
+	directoryMappings map[string]string
+	rommSlugs         map[string]string
+}
+
+func (c romScanConfigStub) GetDirectoryMapping(fsSlug string) (string, bool) {
+	path, ok := c.directoryMappings[fsSlug]
+	return path, ok
+}
+
+func (c romScanConfigStub) ResolveRommFSSlug(cfwKey string) string {
+	if slug, ok := c.rommSlugs[cfwKey]; ok {
+		return slug
+	}
+	return cfwKey
+}
+
+func TestScanRomsByPlatform_NextUIUsesRommFSSlug(t *testing.T) {
+	romRoot := t.TempDir()
+	romDir := filepath.Join(romRoot, "Game Boy Advance (MGBA)")
+	if err := os.Mkdir(romDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	romName := "Final Fantasy Tactics Advance (USA).zip"
+	if err := os.WriteFile(filepath.Join(romDir, romName), []byte("rom"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	config := romScanConfigStub{
+		directoryMappings: map[string]string{"GBA": "Game Boy Advance (MGBA)"},
+		rommSlugs:         map[string]string{"gba": "GBA"},
+	}
+	platforms := map[string][]string{
+		"gba": {"Game Boy Advance (GBA)", "Game Boy Advance (MGBA)"},
+	}
+
+	scan := scanRomsByPlatform(romRoot, platforms, config, NextUI)
+	roms := scan["GBA"]
+	if len(roms) != 1 {
+		t.Fatalf("GBA scan count = %d, want 1 (scan=%+v)", len(roms), scan)
+	}
+	if roms[0].FSSlug != "GBA" || roms[0].FileName != romName {
+		t.Fatalf("resolved ROM = %+v, want RomM slug GBA and file %q", roms[0], romName)
+	}
+	if _, exists := scan["gba"]; exists {
+		t.Fatalf("scan retained CFW slug gba instead of RomM slug: %+v", scan)
+	}
+}

--- a/cfw/saves.go
+++ b/cfw/saves.go
@@ -13,6 +13,7 @@ import (
 	"grout/cfw/rocknix"
 	"grout/cfw/spruce"
 	"grout/cfw/trimui"
+	"grout/internal/stringutil"
 	"path/filepath"
 	"strings"
 )
@@ -98,6 +99,36 @@ func GetSaveDirectory(fsSlug string) string {
 	emulatorDirs := EmulatorFoldersForFSSlug(fsSlug)
 	if len(emulatorDirs) == 0 {
 		return ""
+	}
+
+	return filepath.Join(baseSavePath, emulatorDirs[0])
+}
+
+// GetSaveDirectoryForRomPath resolves the save directory associated with the ROM's
+// actual emulator folder. Tag-based CFWs can expose multiple launchers for one platform
+// (for example NextUI's Game Boy Advance (GBA) and Game Boy Advance (MGBA)); choosing the
+// platform's first save directory would write a valid save where the selected launcher
+// never looks for it.
+//
+// If the ROM folder cannot be correlated with a configured save directory, this falls
+// back to the platform default used by GetSaveDirectory.
+func GetSaveDirectoryForRomPath(fsSlug, romPath string) string {
+	baseSavePath := BaseSavePath()
+	if baseSavePath == "" {
+		return ""
+	}
+
+	emulatorDirs := EmulatorFoldersForFSSlug(fsSlug)
+	if len(emulatorDirs) == 0 {
+		return ""
+	}
+
+	romDir := filepath.Base(filepath.Dir(romPath))
+	romTag := stringutil.ParseTag(romDir)
+	for _, emulatorDir := range emulatorDirs {
+		if strings.EqualFold(emulatorDir, romDir) || (romTag != "" && strings.EqualFold(emulatorDir, romTag)) {
+			return filepath.Join(baseSavePath, emulatorDir)
+		}
 	}
 
 	return filepath.Join(baseSavePath, emulatorDirs[0])

--- a/sync/flow.go
+++ b/sync/flow.go
@@ -132,6 +132,7 @@ func buildDiscoveryItems(uncovered map[int]cfw.LocalRomFile, savesByRom map[int]
 			RomName:     rom.RomName,
 			FSSlug:      rom.FSSlug,
 			RomFileName: rom.FileName,
+			EmulatorDir: resolveDiscoveredSaveDirectory(rom, config),
 		}
 		if IsDirectorySavePlatform(ls.FSSlug) {
 			ls.IsDirectorySave = true
@@ -299,15 +300,10 @@ func mapOperationsToItems(
 ) []SyncItem {
 	logger := gaba.GetLogger()
 
-	type localKey struct {
-		romID    int
-		fileName string
-	}
 	type romSlotKey struct {
 		romID int
 		slot  string
 	}
-	byKey := make(map[localKey]LocalSave, len(localSaves))
 	// byRomSlot indexes local saves by (rom_id, reported slot) — the same key the RomM
 	// orchestrator and Argosy pair on. We must NOT match upload/conflict ops by filename:
 	// the server datetime-tags slot saves (e.g. "Name [2026-06-09_14-49-22].srm") while
@@ -317,7 +313,6 @@ func mapOperationsToItems(
 	// per ROM, so a ROM that already has a local save only ever syncs that save's slot.
 	localByRom := make(map[int]LocalSave, len(localSaves))
 	for _, ls := range localSaves {
-		byKey[localKey{ls.RomID, ls.FileName}] = ls
 		rsk := romSlotKey{ls.RomID, resolveReportedSlot(ls, config, recordedSlots)}
 		if _, ok := byRomSlot[rsk]; !ok {
 			byRomSlot[rsk] = ls
@@ -437,7 +432,11 @@ func mapOperationsToItems(
 		}
 		op := pickDownloadOp(dops, preferred)
 
-		ls, ok := byKey[localKey{op.RomID, op.FileName}]
+		// The server datetime-tags stored save filenames, so a download operation's
+		// filename normally differs from the emulator's plain local filename. The slot
+		// was already checked above; keep the existing local save so its exact path and
+		// emulator directory remain authoritative.
+		ls, ok := localByRom[op.RomID]
 		if !ok {
 			ls = resolveLocalSaveForDownload(op, resolvedRoms, cm)
 		}
@@ -1403,7 +1402,10 @@ func download(client *romm.Client, config *internal.Config, deviceID string, ite
 
 	savePath := item.LocalSave.FilePath
 	if savePath == "" {
-		saveDir := ResolveSaveDirectory(item.LocalSave.FSSlug, config)
+		saveDir := item.LocalSave.EmulatorDir
+		if saveDir == "" {
+			saveDir = ResolveSaveDirectory(item.LocalSave.FSSlug, config)
+		}
 		if saveDir != "" {
 			keepRomExt := detectSaveNameStyle(saveDir)
 			fileName := downloadSaveFileName(item.LocalSave.RomFileName, item.RemoteSave.FileName, item.RemoteSave.FileExtension, keepRomExt)
@@ -1591,4 +1593,17 @@ func ResolveSaveDirectory(fsSlug string, config *internal.Config) string {
 	}
 
 	return cfw.GetSaveDirectory(effectiveFSSlug)
+}
+
+func resolveDiscoveredSaveDirectory(rom cfw.LocalRomFile, config *internal.Config) string {
+	if rom.FilePath == "" {
+		return ""
+	}
+
+	effectiveFSSlug := rom.FSSlug
+	if config != nil {
+		effectiveFSSlug = config.ResolveFSSlug(rom.FSSlug)
+	}
+
+	return cfw.GetSaveDirectoryForRomPath(effectiveFSSlug, rom.FilePath)
 }

--- a/sync/flow_test.go
+++ b/sync/flow_test.go
@@ -41,6 +41,36 @@ func TestBuildDiscoveryItems_NeverSyncedPulled(t *testing.T) {
 	}
 }
 
+func TestBuildDiscoveryItems_NextUIPreservesRomEmulatorDirectory(t *testing.T) {
+	t.Setenv("CFW", "NEXTUI")
+	basePath := t.TempDir()
+	t.Setenv("BASE_PATH", basePath)
+
+	romPath := filepath.Join(basePath, "Roms", "Game Boy Advance (MGBA)", "Final Fantasy Tactics Advance (USA).zip")
+	uncovered := map[int]cfw.LocalRomFile{
+		3112: {
+			RomID:    3112,
+			RomName:  "Final Fantasy Tactics Advance",
+			FSSlug:   "GBA",
+			FileName: "Final Fantasy Tactics Advance (USA).zip",
+			FilePath: romPath,
+		},
+	}
+	savesByRom := map[int][]romm.Save{
+		3112: {{ID: 11, RomID: 3112, FileName: "Final Fantasy Tactics Advance (USA) [2026].srm", FileExtension: "srm", UpdatedAt: time.Now()}},
+	}
+	config := &internal.Config{PlatformsBinding: map[string]string{"GBA": "gba"}}
+
+	items := buildDiscoveryItems(uncovered, savesByRom, config)
+	if len(items) != 1 {
+		t.Fatalf("expected 1 discovery item, got %d", len(items))
+	}
+	wantDir := filepath.Join(basePath, "Saves", "MGBA")
+	if got := items[0].LocalSave.EmulatorDir; got != wantDir {
+		t.Fatalf("EmulatorDir = %q, want %q", got, wantDir)
+	}
+}
+
 func TestBuildDiscoveryItems_AlreadySyncedStillPulled(t *testing.T) {
 	// Discovery only runs when there is no local file, so a save this device synced
 	// before (then lost locally, e.g. after a reflash) MUST still be pulled.
@@ -346,6 +376,37 @@ func TestMapOperationsToItems_UploadMatchesBySlotNotFilename(t *testing.T) {
 	}
 	if items[0].TargetSlot != "autosave" {
 		t.Errorf("target slot = %q, want autosave", items[0].TargetSlot)
+	}
+}
+
+func TestMapOperationsToItems_DownloadKeepsExistingLocalPath(t *testing.T) {
+	localPath := "/mnt/SDCARD/Saves/MGBA/Final Fantasy Tactics Advance (USA).zip.sav"
+	local := []LocalSave{{
+		RomID:       3112,
+		RomName:     "Final Fantasy Tactics Advance",
+		FSSlug:      "GBA",
+		FileName:    "Final Fantasy Tactics Advance (USA).zip.sav",
+		FilePath:    localPath,
+		EmulatorDir: "/mnt/SDCARD/Saves/MGBA",
+	}}
+	ops := []romm.SyncOperationSchema{{
+		Action:          "download",
+		RomID:           3112,
+		SaveID:          ptrInt(13),
+		FileName:        "Final Fantasy Tactics Advance (USA).zip [2026-08-21_06-52-14].sav",
+		Slot:            ptrStr("autosave"),
+		ServerUpdatedAt: ptrTime(time.Now()),
+	}}
+
+	items := mapOperationsToItems(ops, local, nil, nil, nil, nil, nil)
+	if len(items) != 1 {
+		t.Fatalf("expected 1 download item, got %d", len(items))
+	}
+	if got := items[0].LocalSave.FilePath; got != localPath {
+		t.Fatalf("download path = %q, want existing local path %q", got, localPath)
+	}
+	if got := items[0].LocalSave.EmulatorDir; got != "/mnt/SDCARD/Saves/MGBA" {
+		t.Fatalf("emulator dir = %q, want existing MGBA directory", got)
 	}
 }
 


### PR DESCRIPTION
I ran into a problem where I was unable to get my Romm server to sync a save over to my NextUI device (TrimUI Brick). I am not completely sure what happened but I believe it to be the following sequence of events:

1) I already had a copy of a ROM on my device, since I was using it without Grout. This was in the MGBA folder.
2) I connected my device to Grout and downloaded a copy of the game. This placed it in GBA, which I guess was the default.
3) I already had some save progress and wanted to import this into the device. I ran sync and got some files synced and/or pulled down but it looks like it just pushed an `autosave` to ROMM
4) I deleted the blank save file (it came from launching the game I presume, empty with all `FF`) and tried syncing again. Nothing.
5) I tried changing the directory mapping to MGBA (which I prefer to use anyway) and pull again, and nothing.

After futzing around with the SQL Lite DB, it would appear that at some point along the way the sync manager was dropping saves in the GBA folder even though the ROM was in MGBA. It would seem that when pulling fresh, remote saves
Grout was refusing to pull them when using mGBA. Codex did manage to fix this over FTP when I gave it control. The following was generated by Codex and left untouched:

---

* NextUI scanned installed ROMs under CFW keys such as gba while the metadata cache was indexed by RomM slugs such as GBA. This made every local ROM cache lookup miss and prevented remote-only save discovery even when the downloaded ROM basename exactly matched RomM. Resolve the inverse platform binding during NextUI scans and cover the real GBA/MGBA layout with a regression test.
* Preserve the emulator-specific save directory inferred from the installed ROM folder so a ROM launched from Game Boy Advance (MGBA) downloads into Saves/MGBA instead of the platform's default Saves/GBA. For subsequent updates, pair timestamped RomM download operations with the already validated local save by ROM and managed slot, retaining its exact filename, path, and emulator directory rather than constructing a second misplaced file.
* Add regression coverage modeled on the Final Fantasy Tactics Advance failure reproduced on a NextUI TrimUI Brick: initial remote-only discovery now carries MGBA forward, and a newer server save with a datetime-tagged filename overwrites the existing plain local save path. The full Go test suite passes in the project's official SDL-equipped build image.

---

I am attaching this in case it is useful. I have run the tests via Docker but I don't know enough about the codebase to prove correctness. Let me know if this is useful at all.
